### PR TITLE
Fix tcp bind to specific interface

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -261,7 +261,7 @@ impl Drop for ElevatorInterface {
 
 fn main() {
     println!("Elevator server started");
-    let (mut stream, _addr) = TcpListener::bind("localhost:15657").unwrap().accept().unwrap();
+    let (mut stream, _addr) = TcpListener::bind("0.0.0.0:15657").unwrap().accept().unwrap();
     let elevator = ElevatorInterface::open("/dev/comedi0").unwrap();
     println!("Client connected to server");
     


### PR DESCRIPTION
Binding to 0.0.0.0 will allow connections from any interface not just lo.

This resolves some issues for people who run their programs from other network interfaces than the loopback.

@kjetilkjeka @klasbo 